### PR TITLE
Fix country filter display

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -11,3 +11,4 @@
 // Your CSS partials
 @import "components/main";
 @import "pages/main";
+@import "tutors/main";

--- a/app/assets/stylesheets/tutors/_index.scss
+++ b/app/assets/stylesheets/tutors/_index.scss
@@ -1,0 +1,7 @@
+div.dropdown-menu {
+  width: 100%;
+}
+
+.dropdown-item span {
+  white-space: normal;
+}

--- a/app/assets/stylesheets/tutors/_main.scss
+++ b/app/assets/stylesheets/tutors/_main.scss
@@ -1,0 +1,2 @@
+// Import page-specific CSS files here.
+@import "index";

--- a/app/views/tutors/index.html.erb
+++ b/app/views/tutors/index.html.erb
@@ -3,7 +3,7 @@
 <p><%= pluralize(@tutors_nb, 'result') %></p>
 
 <div class="row">
-  <div class="col-3">
+  <div class="col-4">
     <div style="position: sticky; top: 30px;">
       <%= form_tag tutors_path, method: :get do %>
         <p>Subject</p>
@@ -12,7 +12,9 @@
         <%= select_tag(:language_id, options_for_select(Language.pluck(:name, :id), selected: params[:language_id]),  {class: "selectpicker w-75", data: {"live-search": true, "style": "bg-white rounded-pill px-4 py-3 shadow-sm"}, include_blank: 'All'}) %>
         <p>Country</p>
         <%= select_tag(:country, options_for_select(ISO3166::Country.all.sort, selected: params[:country]),  {class: "selectpicker w-75", data: {"live-search": true, "style": "bg-white rounded-pill px-4 py-3 shadow-sm"}, include_blank: 'All'}) %>
-        <%= submit_tag "Search", class: "btn btn-primary mt-3" %>
+        <div class="mt-3">
+          <%= submit_tag "Search", class: "btn btn-primary" %>
+        </div>
       <% end %>
     </div>
   </div>


### PR DESCRIPTION
app > views > tutors > `index.html.erb`:
- change column size containing filter menu

app > assets > `stylesheets`:
- create new folder `tutors`
- create new file `_index.scss` and add style relative to `index.html.erb`
- create new file `_main.scss` and add import `index.scss`
- add import `tutors/main.scss` in `application.scss`

app > assets > stylesheets > tutors > `_index.scss`:
- in js console: found `div` with class `dropdown-menu` and add `width: 100%`
- in js console: found `span` inside `div` with class `dropdown-item` and add `white-space: normal`