### PR TITLE
add smpt settings

### DIFF
--- a/config/initializers/smtp.rb
+++ b/config/initializers/smtp.rb
@@ -1,0 +1,8 @@
+ActionMailer::Base.smtp_settings = {
+  domain: 'https://unicorn-326.herokuapp.com/',
+  address: "smtp.sendgrid.net",
+  port: 587,
+  authentication: :plain,
+  user_name: ENV['USERNAME_SENDGRID'],
+  password: ENV['PASSWORD_SENDGRID']
+}


### PR DESCRIPTION
In `config > initializers`:
- created new file `smtp.rb`
- in this file: added smtp settings such as `domain`, `address`, `port`, `authentication`, `user_name` and `password`
