### PR TITLE
modify default sender email address and delete smtp initializer file

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'catalinebaert@yahoo.com'
+  default from: 'info@brainiak.io'
   layout 'mailer'
 end

--- a/config/initializers/smtp.rb
+++ b/config/initializers/smtp.rb
@@ -1,8 +1,0 @@
-ActionMailer::Base.smtp_settings = {
-  domain: 'https://unicorn-326.herokuapp.com/',
-  address: "smtp.sendgrid.net",
-  port: 587,
-  authentication: :plain,
-  user_name: ENV['USERNAME_SENDGRID'],
-  password: ENV['PASSWORD_SENDGRID']
-}


### PR DESCRIPTION
In `app > mailers > application_mailer.rb`:
- revert default sender email adress to `info@brainiak.com`

In `config > initializers`:
- delete file `smtp.rb`
