### PR TITLE
modify cable production url

### DIFF
--- a/config/cable.yml
+++ b/config/cable.yml
@@ -6,5 +6,5 @@ test:
 
 production:
   adapter: redis
-  url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
+  url: <%= ENV.fetch("REDISCLOUD_URL") { "redis://localhost:6379/1" } %>
   channel_prefix: unicorn326_production


### PR DESCRIPTION
In `config > cable.yml`:
- change `REDIS_URL` to `REDISCLOUD_URL`
