### PR TITLE
Revert "Bump jquery from 3.4.1 to 3.5.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "@rails/webpacker": "4.2.2",
     "bootstrap": "^4.4.1",
     "bootstrap-select": "^1.13.12",
-    "jquery": "^3.5.0",
+    "jquery": "^3.4.1",
     "popper.js": "^1.16.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3817,10 +3817,10 @@ jest-worker@^25.1.0:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
 
-jquery@^3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.0.tgz#9980b97d9e4194611c36530e7dc46a58d7340fc9"
-  integrity sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ==
+jquery@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
+  integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==
 
 js-base64@^2.1.8:
   version "2.5.2"


### PR DESCRIPTION
Reverts ctln12/unicorn326#101
Causes problems with bootstrap select (https://github.com/snapappointments/bootstrap-select/issues/2430)