### PR TITLE
Refactor code for navbar style on home page

### DIFF
--- a/app/assets/stylesheets/components/_banner.scss
+++ b/app/assets/stylesheets/components/_banner.scss
@@ -3,9 +3,6 @@
   background-size: cover;
   background-position: center;
   height: 100vh;
-  position: absolute;
-  top: 0;
-  left: 0;
   width: 100%;
   color: white;
   margin-bottom: 0;
@@ -34,12 +31,13 @@
 }
 
 .btn-banner {
-  background-color: #00002f;
+  background-color: $dark-blue;
   color: white;
-  border: 1px solid #00002F;
-  border-radius: $border-radius-lg;
-  padding: 10px 20px;
+  border: 1px solid $dark-blue;
+  border-radius: 28px;
+  padding: 15px 40px;
   font-weight: 500;
+  box-shadow: 1px 2px 3px rgba(255, 255, 255, 0.1);
 
   &:hover {
     background-color: white;

--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -11,27 +11,38 @@
   width: 40px;
 }
 
-.home-navbar {
-  background: none;
+.navbar-home.navbar-light {
+  position: absolute;
+  width: 100%;
+  background: transparent;
   z-index: 10;
 
-  a {
+  .nav-link {
     color: white;
 
     &:hover {
       color: $dark-blue;
       border-bottom: 1px solid $dark-blue;
+      text-shadow: 1px 2px 3px rgba(255, 255, 255, 0.2);
     }
   }
 
-  a.navbar-brand {
+  .navbar-brand {
     font-size: 1.5rem;
     font-weight: bold;
     color: white;
   }
 
-  a.navbar-brand:hover {
+  .navbar-brand:hover {
     color: white;
     border-bottom: none;
   }
+}
+
+.toggler-home .navbar-toggler-icon {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath stroke='rgba(255,255,255, 1)' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 8h24M4 16h24M4 24h24'/%3E%3C/svg%3E");
+}
+
+.toggler-home.navbar-toggler {
+  border-color: white;
 }

--- a/app/assets/stylesheets/config/_bootstrap_variables.scss
+++ b/app/assets/stylesheets/config/_bootstrap_variables.scss
@@ -25,4 +25,3 @@ $border-radius-sm: 2px;
 // Override other variables below!
 $body-bg: white;
 $body-color: $dark-blue;
-$border-radius-lg: 25px;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,9 +21,7 @@
       <%= render 'shared/navbar' %>
     <% end %>
     <%= render 'shared/flashes' %>
-    <div class="container">
-      <%= yield %>
-    </div>
+    <%= yield %>
     <%= javascript_include_tag 'application' %>
     <%= javascript_pack_tag 'application' %>
   </body>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,4 +1,6 @@
-<%# banner banner-container %>
+<% content_for(:navbar_class, "navbar-home") %>
+<% content_for(:toggler_class, "toggler-home") %>
+
 <div class="jumbotron jumbotron-fluid banner">
   <div class="container banner-container">
     <h1 class="display-4">Learn on any schedule</h1>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,8 +1,8 @@
-<div class="navbar navbar-expand-sm navbar-lewagon<%= ' home-navbar' if params[:controller] == 'pages' && params[:action] == "home" %>">
+<div class="navbar navbar-expand-sm navbar-light navbar-lewagon <%= yield(:navbar_class) %>">
   <%= link_to 'Brainiak', root_path, class: "navbar-brand" %>
 
-  <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-    <span class="navbar-toggler-icon"></span>
+  <button class="navbar-toggler <%= yield(:toggler_class) %>" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+    <span class="navbar-toggler-icon <%= yield(:toggler_class) %>"></span>
   </button>
 
 


### PR DESCRIPTION
I refactored how to add the `navbar-home` class to the navbar only on the home page thanks to Le Wagon's [tutorial](https://kitt.lewagon.com/knowledge/tutorials/css_home_page).

I modified the color of the navbar toggler for mobile view only on the home page using the method from the same tutorial.

Finally I made some small style changes to the banner.